### PR TITLE
Update fennec version check for new android api number

### DIFF
--- a/script.py
+++ b/script.py
@@ -8,7 +8,7 @@ def get_nightly_version():
 
 
 def get_latest_nightly_buildID(version):
-    r = requests.get('https://archive.mozilla.org/pub/mobile/nightly/latest-mozilla-central-android-api-15/fennec-' + version + '.multi.android-arm_info.txt')
+    r = requests.get('https://archive.mozilla.org/pub/mobile/nightly/latest-mozilla-central-android-api-16/fennec-' + version + '.multi.android-arm_info.txt')
     return r.text[len('buildID='):-1]
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1384482 changed where fennec builds are uploaded.