### PR TITLE
Make travis script run on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 - pip install -r test-requirements.txt
 script:
 - flake8 .
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && python script.py'
+- 'python script.py'
 notifications:
   email:
     - mcastelluccio@mozilla.com


### PR DESCRIPTION
The script is only set to run on master outside of PRs; let's not make
it exit with an error if those conditions aren't met.